### PR TITLE
fix: use %H instead of %I to get correct hour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # go tool nm ./luet | grep Commit
-override LDFLAGS += -X "github.com/macaroni-os/mark-devkit/cmd.BuildTime=$(shell date -u '+%Y-%m-%d %I:%M:%S %Z')"
+override LDFLAGS += -X "github.com/macaroni-os/mark-devkit/cmd.BuildTime=$(shell date -u '+%Y-%m-%d %H:%M:%S %Z')"
 override LDFLAGS += -X "github.com/macaroni-os/mark-devkit/cmd.BuildCommit=$(shell git rev-parse HEAD)"
 
 NAME ?= mark-devkit


### PR DESCRIPTION
Problem:

After `make build` at 22:14 EEST (19:14 UTC) running `mark-testing --version` I get

```
version 0.16.3-g60aac73ae55a02607b3d7dc73bab70a25309198c 2025-04-23 07:10:26 UTC
```

i.e. "07" hour, which is incorrect.

Solution:

Use `%H` (00..24) instead of `%I` (00..12).